### PR TITLE
Fix primitive list handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,12 +41,22 @@ exports.convert = (obj) => {
 
             } else if (Array.isArray(cell)) {
 
-                result[key_new] = [];
+                if ( typeof cell[0] === 'object' ) {
 
-                cell.forEach(value => {
+                    result[key_new] = [];
 
-                    result[key_new].push(convert(value, key_new, true))
-                })
+                    cell.forEach(value => {
+
+                        result[key_new].push(convert(value, key_new, true))
+                    })
+
+                } else {
+
+                    // It's not an object array, so treat
+                    // it as an array of Bubble primitives.
+                    //
+                    result[key_new] = cell;
+                }
             }
         });
 


### PR DESCRIPTION
Previously, all arrays were assumed to be arrays of objects. As a result, arrays of strings, numbers, or booleans would be incorrectly handled. String array items would each be converted to an array of characters, and boolean or number array items would be converted to empty objects.

This fix simply uses the "primitive" array itself as the converted value.

Specifically, given the following as input...

```
{
    "obj1": {
        "str": "str",
        "num": 84746,
        "boo": false,
        "obj2": {
            "str_ar": [
                "str1",
                "str2",
                "str3"
            ],
            "num_ar": [
                123.0,
                8,
                87.032
            ],
            "bool_ar": [
                false,
                true,
                true
            ]
        }
    }
}
```

...the following would have been output...


```
{
    "_p_obj1.str"          : "str",
    "_p_obj1.num"          : 84746,
    "_p_obj1.boo"          : false,
    "_p_obj1.obj2.str_ar"  : [
	    {
		    "_p_0" : "s",
		    "_p_1" : "t",
		    "_p_2" : "r",
		    "_p_3" : "1"
	    },{
		    "_p_0" : "s",
		    "_p_1" : "t",
		    "_p_2" : "r",
		    "_p_3" : "2"
	    },{
		    "_p_0" : "s",
		    "_p_1" : "t",
		    "_p_2" : "r",
		    "_p_3" : "3"
	    }
    ],
    "_p_obj1.obj2.num_ar"  : [
	    {},
	    {},
	    {}
    ],
    "_p_obj1.obj2.bool_ar" : [
	    {},
	    {},
	    {}
    ]
}
```

With this fix, the output is now...

```
{
	"_p_obj1.str"          : "str",
	"_p_obj1.num"          : 84746,
	"_p_obj1.boo"          : false,
	"_p_obj1.obj2.str_ar"  : [
		"str1",
		"str2",
		"str3"
	],
	"_p_obj1.obj2.num_ar"  : [
		123,
		8,
		87.032
	],
	"_p_obj1.obj2.bool_ar" : [
		false,
		true,
		true
	]
};
```
